### PR TITLE
unique toplevel scope

### DIFF
--- a/UnityC#.tmLanguage
+++ b/UnityC#.tmLanguage
@@ -546,7 +546,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.cs</string>
+	<string>source.cs.unity3d</string>
 	<key>uuid</key>
 	<string>4621aa92-1182-4d71-b3de-6c87bb233934</string>
 </dict>

--- a/UnityJavaScript.tmLanguage
+++ b/UnityJavaScript.tmLanguage
@@ -747,7 +747,7 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.js</string>
+	<string>source.js.unity3d</string>
 	<key>uuid</key>
 	<string>93E017CC-6F27-11D9-90EB-000D93589AF6</string>
 </dict>


### PR DESCRIPTION
Sublime Text assigns icons by scope name. To be able to assign unique unity3d icons to C#/JS a unique toplevel scope name is required.

see: https://github.com/SublimeText/AFileIcon/issues/12